### PR TITLE
Switch to ubuntu-debootstrap:14.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-FROM ubuntu:trusty
+FROM ubuntu-debootstrap:14.04
 MAINTAINER OpDemand <info@opdemand.com>
+
+RUN apt-get update && \
+  apt-get install -y netcat-openbsd && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV POWERED_BY Deis
 CMD while true; do echo "HTTP/1.1 200 OK\n\nPowered by $POWERED_BY" | nc -l -p 1500; done


### PR DESCRIPTION
This saves another 100mb image size and some deis components are already using `ubuntu-debootstrap:14.04` so its likely already pulled.

```
$ docker images | grep example
example-after                             latest              5c5002266a68        5 seconds ago       87.16 MB
example-before                            latest              9025170bd3f0        6 minutes ago       192.7 MB
$ docker run -i -t example-after /bin/bash
root@c22cb636e444:/# 
```
