### PR TITLE
ref(Dockerfile): improve Russian syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log
 RUN ln -sf /dev/stderr /var/log/nginx/error.log
 
 # echo some unicode as a regression test for https://github.com/deis/dockerbuilder/issues/49
-RUN echo двенадцать фактор для жизни
+RUN echo Кубернетис в каждый датацентр!
 
 ENV POWERED_BY Deis
 


### PR DESCRIPTION
It was pointed out that the UTF-8 string in the Dockerfile wasn't grammatically correct Russian. This replaces it with a better phrase that translates to "Kubernetes in every datacenter!"